### PR TITLE
Silence autoconf warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
 
   GCC_VERSION=no
   AC_MSG_CHECKING([for GCC 2])
-  AC_COMPILE_IFELSE([
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #if ((__GNUC__ == 2) && (__GNUC_MINOR__ >= 0))
 int main(void) { return 0; }
 #else
@@ -165,10 +165,10 @@ int main(void) { return 0; }
 #endif
 ],
   [AC_MSG_RESULT([yes]); GCC_VERSION=2],
-  [AC_MSG_RESULT([no])])
+  [AC_MSG_RESULT([no])])])
 
   AC_MSG_CHECKING([for GCC 3 or newer])
-  AC_COMPILE_IFELSE([
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([
 #if ((__GNUC__ >= 3) && (__GNUC_MINOR__ >= 0))
 int main(void) { return 0; }
 #else
@@ -176,7 +176,7 @@ int main(void) { return 0; }
 #endif
 ],
   [AC_MSG_RESULT([yes]); GCC_VERSION=3],
-  [AC_MSG_RESULT([no])])
+  [AC_MSG_RESULT([no])])])
 
   if [[ "x$GCCVER" != "xno" ]]; then
     GCCVER="$GCC_VERSION"

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 dnl Generator configure.in file - process with autoconf
 
-  AC_INIT
-AC_CONFIG_SRCDIR([cpu68k/def68k.c])
+  AC_INIT([generator], [0.35])
+  AC_CONFIG_SRCDIR([cpu68k/def68k.c])
   AC_PREREQ(2.59)
   AC_CANONICAL_TARGET([])
-  AM_INIT_AUTOMAKE(generator, 0.35)
+  AM_INIT_AUTOMAKE
   AC_CONFIG_HEADERS([config.h])
   optimum=yes
 

--- a/glade/Makefile.am
+++ b/glade/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-INCLUDES = -I../hdr -I../gtkopts -I. @GTK_CFLAGS@
+AM_CPPFLAGS = -I../hdr -I../gtkopts -I. @GTK_CFLAGS@
 
 noinst_LIBRARIES = libglade.a
 libglade_a_SOURCES = support.c interface.c callbacks.c

--- a/gtkopts/Makefile.am
+++ b/gtkopts/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-INCLUDES = -I../hdr -I.
+AM_CPPFLAGS = -I../hdr -I.
 
 noinst_LIBRARIES = libgtkopts.a
 libgtkopts_a_SOURCES = gtkopts.c

--- a/jgz80/Makefile.am
+++ b/jgz80/Makefile.am
@@ -1,3 +1,3 @@
 ## Process this file with automake to produce Makefile.in
 
-INCLUDES = -I.
+AM_CPPFLAGS = -I.

--- a/main/Makefile.am
+++ b/main/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-INCLUDES = -I../hdr -I. -I../cpu68k -I../ym2612 @Z80_INC@ \
+AM_CPPFLAGS = -I../hdr -I. -I../cpu68k -I../ym2612 @Z80_INC@ \
            -I../sn76496 -I../gtkopts \
            -DFNAME_TCLSCRIPT=\"${datadir}/generator/gen.tcl\" \
            @GTK_CFLAGS@ @SDL_CFLAGS@

--- a/sn76496/Makefile.am
+++ b/sn76496/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-INCLUDES = -I../hdr -I.
+AM_CPPFLAGS = -I../hdr -I.
 
 noinst_LIBRARIES = libsn76496.a
 libsn76496_a_SOURCES = sn76496.c

--- a/ym2612/Makefile.am
+++ b/ym2612/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-INCLUDES = -I../hdr -I.
+AM_CPPFLAGS = -I../hdr -I.
 
 noinst_LIBRARIES = libym2612.a
 libym2612_a_SOURCES = fm.c


### PR DESCRIPTION
This silences the warnings when using `autoreconf` from `autoconf-2.69`. See the commit messages for the warnings.